### PR TITLE
ScatteringByteChannel #13

### DIFF
--- a/src/main/scala/scalaz/nio/channels/AsynchronousByteChannel.scala
+++ b/src/main/scala/scalaz/nio/channels/AsynchronousByteChannel.scala
@@ -8,9 +8,8 @@ import java.nio.channels.{
   AsynchronousSocketChannel => JAsynchronousSocketChannel,
   CompletionHandler => JCompletionHandler
 }
-import java.nio.{ ByteBuffer => JByteBuffer }
 
-import scalaz.nio.Buffer
+import scalaz.nio.ByteBuffer
 import scalaz.zio.{ Async, ExitResult, IO }
 
 class AsynchronousByteChannel(private val channel: JAsynchronousByteChannel) {
@@ -19,10 +18,10 @@ class AsynchronousByteChannel(private val channel: JAsynchronousByteChannel) {
    *  Reads data from this channel into buffer, returning the number of bytes
    *  read, or -1 if no bytes were read.
    */
-  final def read(b: Buffer[Byte]): IO[Exception, Int] =
+  final def read(b: ByteBuffer): IO[Exception, Int] =
     IO.async0[Exception, Int] { k =>
       try {
-        val byteBuffer = b.buffer.asInstanceOf[JByteBuffer]
+        val byteBuffer = b.buffer
         channel.read(
           byteBuffer,
           (),
@@ -48,10 +47,10 @@ class AsynchronousByteChannel(private val channel: JAsynchronousByteChannel) {
   /**
    *  Writes data into this channel from buffer, returning the number of bytes written.
    */
-  final def write(b: Buffer[Byte]): IO[Exception, Int] =
+  final def write(b: ByteBuffer): IO[Exception, Int] =
     IO.async0[Exception, Int] { k =>
       try {
-        val byteBuffer = b.buffer.asInstanceOf[JByteBuffer]
+        val byteBuffer = b.buffer
         channel.write(
           byteBuffer,
           (),

--- a/src/main/scala/scalaz/nio/channels/ScatteringByteChannel.scala
+++ b/src/main/scala/scalaz/nio/channels/ScatteringByteChannel.scala
@@ -1,0 +1,17 @@
+package scalaz.nio.channels
+
+import java.nio.channels.{ ScatteringByteChannel => JScatteringByteChannel }
+
+import scalaz.nio.ByteBuffer
+import scalaz.zio.IO
+
+class ScatteringByteChannel(private val channel: JScatteringByteChannel) {
+
+  def read(dsts: Seq[ByteBuffer], offset: Int, length: Int): IO[Exception, Long] =
+    IO.syncException(channel.read(unwrap(dsts), offset, length))
+
+  def read(dsts: Seq[ByteBuffer]): IO[Exception, Long] =
+    IO.syncException(channel.read(unwrap(dsts)))
+
+  private def unwrap(dsts: Seq[ByteBuffer]) = dsts.map(d => d.buffer).toArray
+}

--- a/src/main/tut/channel.md
+++ b/src/main/tut/channel.md
@@ -44,7 +44,7 @@ object T {
         arr        <- bufferDest.array
 
         _ <- log(
-              "Read: " + n.toString + " Bytes. Content: " + arr.toOption.get.mkString
+              "Read: " + n.toString + " Bytes. Content: " + arr.mkString
             )
       } yield ()
     }
@@ -61,9 +61,9 @@ object T {
         // TODO is this the right way of reading from the buffer?
         bufferSrc <- Buffer.byte(8)
         arr       <- bufferSrc.array
-        _         = arr.toOption.get.update(0, 1)
+        _         = arr.update(0, 1)
 
-        _ <- log("Gonna write: " + arr.toOption.get.mkString)
+        _ <- log("Gonna write: " + arr.mkString)
         _ <- client.write(bufferSrc)
       } yield ()
     }


### PR DESCRIPTION
plus changed `Buffer` design a bit:

- wrapped JBuffer as a type parameter is helpful since prevents casting - which otherwise would be needed in most of the channels. Should also not affect library clients since it is hidden behind factory methods.
- `array` is moved to subclasses for less casting, it also cannot be nullable
- not sure for the `get` method and for  casting of `array of A` to `get: A`, I have removed it. @ysusuk I hope I haven't misinterpreted anything - otherwise please let me know how you intended to use it and I will redo/include the `get` again.