### PR TITLE
High level API for Socket Client

### DIFF
--- a/src/main/scala/scalaz/nio/Buffer.scala
+++ b/src/main/scala/scalaz/nio/Buffer.scala
@@ -61,6 +61,9 @@ object ByteBuffer {
 
   def apply(capacity: Int): IO[Exception, ByteBuffer] =
     IO.syncException(JByteBuffer.allocate(capacity)).map(new ByteBuffer(_))
+
+  def apply(bytes: Array[Byte]): IO[Exception, ByteBuffer] =
+    IO.syncException(JByteBuffer.wrap(bytes)).map(new ByteBuffer(_))
 }
 
 object Buffer {

--- a/src/main/scala/scalaz/nio/channels/SocketClient.scala
+++ b/src/main/scala/scalaz/nio/channels/SocketClient.scala
@@ -1,0 +1,34 @@
+package scalaz.nio.channels
+
+import java.net.SocketAddress
+import scalaz.nio.ByteBuffer
+import scalaz.zio.{ IO, Managed }
+
+class SocketClient private (channel: AsynchronousSocketChannel) {
+
+  def write(bytes: Array[Byte]): IO[Exception, Unit] =
+    for {
+      buffer <- ByteBuffer(bytes)
+      _      <- channel.write(buffer)
+    } yield ()
+
+  def read(numBytes: Int): IO[Exception, Array[Byte]] =
+    for {
+      buffer <- ByteBuffer(numBytes)
+      _      <- channel.read(buffer)
+      array  <- buffer.array
+    } yield array
+
+  def close: IO[Exception, Unit] = channel.close
+
+}
+
+object SocketClient {
+
+  def apply(socketAddress: SocketAddress): Managed[Exception, SocketClient] =
+    Managed(for {
+      channel <- AsynchronousSocketChannel()
+      _       <- channel.connect(socketAddress)
+    } yield new SocketClient(channel))(_.close.attempt.void)
+
+}

--- a/src/main/scala/scalaz/nio/channels/SocketClient.scala
+++ b/src/main/scala/scalaz/nio/channels/SocketClient.scala
@@ -1,21 +1,21 @@
 package scalaz.nio.channels
 
-import scalaz.nio.{ByteBuffer, InetSocketAddress, SocketAddress}
-import scalaz.zio.{IO, Managed}
+import scalaz.nio.{ ByteBuffer, InetSocketAddress, SocketAddress }
+import scalaz.zio.{ IO, Managed }
 
 class SocketClient private (channel: AsynchronousSocketChannel) {
 
   def write(bytes: Array[Byte]): IO[Exception, Unit] =
     for {
       buffer <- ByteBuffer(bytes)
-      _ <- channel.write(buffer)
+      _      <- channel.write(buffer)
     } yield ()
 
   def read(numBytes: Int): IO[Exception, Array[Byte]] =
     for {
       buffer <- ByteBuffer(numBytes)
-      _ <- channel.read(buffer)
-      array <- buffer.array
+      _      <- channel.read(buffer)
+      array  <- buffer.array
     } yield array
 
   def close: IO[Exception, Unit] = channel.close
@@ -28,13 +28,13 @@ object SocketClient {
     Managed(for {
       address <- SocketAddress.inetSocketAddress(host, port)
       channel <- AsynchronousSocketChannel()
-      _ <- channel.connect(address)
+      _       <- channel.connect(address)
     } yield new SocketClient(channel))(_.close.attempt.void)
 
   def apply(address: InetSocketAddress): Managed[Exception, SocketClient] =
     Managed(for {
       channel <- AsynchronousSocketChannel()
-      _ <- channel.connect(address)
+      _       <- channel.connect(address)
     } yield new SocketClient(channel))(_.close.attempt.void)
 
 }

--- a/src/test/scala/scalaz/nio/ChannelSuite.scala
+++ b/src/test/scala/scalaz/nio/ChannelSuite.scala
@@ -5,8 +5,8 @@ import scalaz.nio.channels.{
   AsynchronousSocketChannel,
   SocketClient
 }
-import scalaz.zio.{IO, RTS}
-import testz.{Harness, assert}
+import scalaz.zio.{ IO, RTS }
+import testz.{ Harness, assert }
 
 object ChannelSuite extends RTS {
 
@@ -20,37 +20,37 @@ object ChannelSuite extends RTS {
         def echoServer: IO[Exception, Unit] =
           for {
             address <- inetAddress
-            sink <- Buffer.byte(3)
-            server <- AsynchronousServerSocketChannel()
-            _ <- server.bind(address)
-            worker <- server.accept
-            _ <- worker.read(sink)
-            _ <- sink.flip
-            _ <- worker.write(sink)
-            _ <- worker.close
-            _ <- server.close
+            sink    <- Buffer.byte(3)
+            server  <- AsynchronousServerSocketChannel()
+            _       <- server.bind(address)
+            worker  <- server.accept
+            _       <- worker.read(sink)
+            _       <- sink.flip
+            _       <- worker.write(sink)
+            _       <- worker.close
+            _       <- server.close
           } yield ()
 
         def echoClient: IO[Exception, Boolean] =
           for {
-            address <- inetAddress
-            src <- Buffer.byte(3)
-            client <- AsynchronousSocketChannel()
-            _ <- client.connect(address)
-            sent <- src.array
-            _ = sent.update(0, 1)
-            _ <- client.write(src)
-            _ <- src.flip
-            _ <- client.read(src)
+            address  <- inetAddress
+            src      <- Buffer.byte(3)
+            client   <- AsynchronousSocketChannel()
+            _        <- client.connect(address)
+            sent     <- src.array
+            _        = sent.update(0, 1)
+            _        <- client.write(src)
+            _        <- src.flip
+            _        <- client.read(src)
             received <- src.array
-            _ <- client.close
+            _        <- client.close
           } yield sent.sameElements(received)
 
         val testProgram: IO[Exception, Boolean] = for {
           serverFiber <- echoServer.fork
           clientFiber <- echoClient.fork
-          _ <- serverFiber.join
-          same <- clientFiber.join
+          _           <- serverFiber.join
+          same        <- clientFiber.join
         } yield same
 
         assert(unsafeRun(testProgram))
@@ -62,32 +62,32 @@ object ChannelSuite extends RTS {
         def echoServer: IO[Exception, Unit] =
           for {
             address <- inetAddress
-            sink <- Buffer.byte(3)
-            server <- AsynchronousServerSocketChannel()
-            _ <- server.bind(address)
-            worker <- server.accept
-            _ <- worker.read(sink)
-            _ <- sink.flip
-            _ <- worker.write(sink)
-            _ <- worker.close
-            _ <- server.close
+            sink    <- Buffer.byte(3)
+            server  <- AsynchronousServerSocketChannel()
+            _       <- server.bind(address)
+            worker  <- server.accept
+            _       <- worker.read(sink)
+            _       <- sink.flip
+            _       <- worker.write(sink)
+            _       <- worker.close
+            _       <- server.close
           } yield ()
 
         def echoClient(address: InetSocketAddress): IO[Exception, Boolean] =
           SocketClient(address).use { client =>
             val sent: Array[Byte] = Array(0, 1, 2)
             for {
-              _ <- client.write(sent)
+              _        <- client.write(sent)
               received <- client.read(sent.length)
             } yield sent.sameElements(received)
           }
 
         val testProgram: IO[Exception, Boolean] = for {
-          address <- inetAddress
+          address     <- inetAddress
           serverFiber <- echoServer.fork
           clientFiber <- echoClient(address).fork
-          _ <- serverFiber.join
-          same <- clientFiber.join
+          _           <- serverFiber.join
+          same        <- clientFiber.join
         } yield same
 
         assert(unsafeRun(testProgram))

--- a/src/test/scala/scalaz/nio/ChannelSuite.scala
+++ b/src/test/scala/scalaz/nio/ChannelSuite.scala
@@ -1,8 +1,11 @@
 package scalaz.nio
 
 import java.net.InetSocketAddress
-
-import scalaz.nio.channels.{ AsynchronousServerSocketChannel, AsynchronousSocketChannel }
+import scalaz.nio.channels.{
+  AsynchronousServerSocketChannel,
+  AsynchronousSocketChannel,
+  SocketClient
+}
 import scalaz.zio.{ IO, RTS }
 import testz.{ Harness, assert }
 
@@ -10,44 +13,80 @@ object ChannelSuite extends RTS {
 
   def tests[T](harness: Harness[T]): T = {
     import harness._
-    section(test("read/write") { () =>
-      val address = new InetSocketAddress(1337)
+    section(
+      test("read/write") { () =>
+        val address = new InetSocketAddress(1337)
 
-      def echoServer: IO[Exception, Unit] =
-        for {
-          sink   <- Buffer.byte(3)
-          server <- AsynchronousServerSocketChannel()
-          _      <- server.bind(address)
-          worker <- server.accept
-          _      <- worker.read(sink)
-          _      <- sink.flip
-          _      <- worker.write(sink)
-          _      <- worker.close
-          _      <- server.close
-        } yield ()
+        def echoServer: IO[Exception, Unit] =
+          for {
+            sink   <- Buffer.byte(3)
+            server <- AsynchronousServerSocketChannel()
+            _      <- server.bind(address)
+            worker <- server.accept
+            _      <- worker.read(sink)
+            _      <- sink.flip
+            _      <- worker.write(sink)
+            _      <- worker.close
+            _      <- server.close
+          } yield ()
 
-      def echoClient: IO[Exception, Boolean] =
-        for {
-          src      <- Buffer.byte(3)
-          client   <- AsynchronousSocketChannel()
-          _        <- client.connect(address)
-          sent     <- src.array
-          _        = sent.update(0, 1)
-          _        <- client.write(src)
-          _        <- src.flip
-          _        <- client.read(src)
-          received <- src.array
-          _        <- client.close
-        } yield sent.sameElements(received)
+        def echoClient: IO[Exception, Boolean] =
+          for {
+            src      <- Buffer.byte(3)
+            client   <- AsynchronousSocketChannel()
+            _        <- client.connect(address)
+            sent     <- src.array
+            _        = sent.update(0, 1)
+            _        <- client.write(src)
+            _        <- src.flip
+            _        <- client.read(src)
+            received <- src.array
+            _        <- client.close
+          } yield sent.sameElements(received)
 
-      val testProgram: IO[Exception, Boolean] = for {
-        serverFiber <- echoServer.fork
-        clientFiber <- echoClient.fork
-        _           <- serverFiber.join
-        same        <- clientFiber.join
-      } yield same
+        val testProgram: IO[Exception, Boolean] = for {
+          serverFiber <- echoServer.fork
+          clientFiber <- echoClient.fork
+          _           <- serverFiber.join
+          same        <- clientFiber.join
+        } yield same
 
-      assert(unsafeRun(testProgram))
-    })
+        assert(unsafeRun(testProgram))
+      },
+      test("read/write with SocketClient") { () =>
+        val address = new InetSocketAddress(1337)
+
+        def echoServer: IO[Exception, Unit] =
+          for {
+            sink   <- Buffer.byte(3)
+            server <- AsynchronousServerSocketChannel()
+            _      <- server.bind(address)
+            worker <- server.accept
+            _      <- worker.read(sink)
+            _      <- sink.flip
+            _      <- worker.write(sink)
+            _      <- worker.close
+            _      <- server.close
+          } yield ()
+
+        def echoClient: IO[Exception, Boolean] =
+          SocketClient(address).use { client =>
+            val sent: Array[Byte] = Array(0, 1, 2)
+            for {
+              _        <- client.write(sent)
+              received <- client.read(sent.length)
+            } yield sent.sameElements(received)
+          }
+
+        val testProgram: IO[Exception, Boolean] = for {
+          serverFiber <- echoServer.fork
+          clientFiber <- echoClient.fork
+          _           <- serverFiber.join
+          same        <- clientFiber.join
+        } yield same
+
+        assert(unsafeRun(testProgram))
+      }
+    )
   }
 }


### PR DESCRIPTION
This is an example of what I was suggesting in #42 : a simpler wrapper on top of our NIO wrapper to expose features in an easy way for users of the library.

I took the example of the socket client, which can be simply used like this:
```scala
SocketClient(address).use { client =>
  for {
  _        <- client.write(Array(0, 1, 2))
  received <- client.read(3)
  } yield received
}
```

What do you think about offering something like that?