### PR TITLE
Issue 72 - replace IO.successful with IO.sync

### DIFF
--- a/src/main/scala/scalaz/nio/Buffer.scala
+++ b/src/main/scala/scalaz/nio/Buffer.scala
@@ -16,18 +16,18 @@ import scala.reflect.ClassTag
 
 @specialized // See if Specialized will work on return values, e.g. `get`
 abstract class Buffer[A: ClassTag, B <: JBuffer] private[nio] (private[nio] val buffer: B) {
-  final def capacity: IO[Nothing, Int] = IO.succeed(buffer.capacity)
+  final val capacity: IO[Nothing, Int] = IO.succeed(buffer.capacity)
 
-  final def position: IO[Nothing, Int] = IO.succeed(buffer.position)
+  final def position: IO[Nothing, Int] = IO.sync(buffer.position)
 
   final def position(newPosition: Int): IO[Exception, Unit] =
     IO.syncException(buffer.position(newPosition)).void
 
-  final def limit: IO[Nothing, Int] = IO.succeed(buffer.limit)
+  final def limit: IO[Nothing, Int] = IO.sync(buffer.limit)
 
-  final def remaining: IO[Nothing, Int] = IO.succeed(buffer.remaining)
+  final def remaining: IO[Nothing, Int] = IO.sync(buffer.remaining)
 
-  final def hasRemaining: IO[Nothing, Boolean] = IO.succeed(buffer.hasRemaining)
+  final def hasRemaining: IO[Nothing, Boolean] = IO.sync(buffer.hasRemaining)
 
   final def limit(newLimit: Int): IO[Exception, Unit] =
     IO.syncException(buffer.limit(newLimit)).void
@@ -43,13 +43,13 @@ abstract class Buffer[A: ClassTag, B <: JBuffer] private[nio] (private[nio] val 
 
   final def rewind: IO[Nothing, Unit] = IO.sync(buffer.rewind()).void
 
-  final def isReadOnly: IO[Nothing, Boolean] = IO.succeed(buffer.isReadOnly)
+  final val isReadOnly: IO[Nothing, Boolean] = IO.succeed(buffer.isReadOnly)
 
   def array: IO[Exception, Array[A]]
 
-  final def hasArray: IO[Nothing, Boolean] = IO.succeed(buffer.hasArray)
-  final def arrayOffset: IO[Nothing, Int]  = IO.succeed(buffer.arrayOffset)
-  final def isDirect: IO[Nothing, Boolean] = IO.succeed(buffer.isDirect)
+  final val hasArray: IO[Nothing, Boolean]  = IO.succeed(buffer.hasArray)
+  final def arrayOffset: IO[Exception, Int] = IO.syncException(buffer.arrayOffset)
+  final val isDirect: IO[Nothing, Boolean]  = IO.succeed(buffer.isDirect)
 
 }
 


### PR DESCRIPTION
@ysusuk - please take a look at one test I've changed (original code fails with this change test). I hope it explains why we cannot use `IO.succeed` to wrap calls to mutable state.
If you agree with these changes, tell me then I'll update other tests as well.